### PR TITLE
feat: allow invalidating a compilation in watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The compiler inherits from [EventEmitter](https://nodejs.org/api/events.html) an
 | begin | Emitted when a compilation starts | |
 | error | Emitted when the compilation fails | (err: Error) |
 | end | Emitted when the compilation completes successfully | ({ stats: WebpackStats, duration: Number }) |
+| invalidate | Emitted when the function return by .watch is called | |
 
 ```js
 compiler
@@ -56,6 +57,9 @@ compiler
 .on('end', ({ stats, duration }) => {
     console.log(`Compilation finished successfully (${duration}ms)`);
     console.log('Stats', stats);
+})
+.on('invalidate', () => {
+    console.log('Compilation canceled. Starting new compilation.')
 })
 .on('error', (err) => {
     console.log('Compilation failed')
@@ -87,7 +91,7 @@ compiler.run()
 ### .watch([options], [handler])
 
 Starts watching for changes and compiles on-the-fly.   
-Returns itself to allow chaining.
+Returns a function that, when called, will stop an ongoing compilation and start a new one.
 
 Calls `handler` everytime the compilation fails or succeeds.
 This is similar to webpack's watch() method, except that `handler` gets called with an error if stats contains errors.
@@ -100,7 +104,7 @@ Available options:
 | aggregateTimeout | Wait so long for more changes (ms) | err | 200 |
 
 ```js
-compiler.watch((err, { stats, duration }) => {
+const invalidate = compiler.watch((err, { stats, duration }) => {
     // err = {
     //   message: 'Error message',
     //   [stats]: <webpack-stats>
@@ -108,6 +112,10 @@ compiler.watch((err, { stats, duration }) => {
     // stats is the webpack stats
     // duration is the time it took to compile
 });
+
+if (someReasonToTriggerARecompilation) {
+    invalidate();
+}
 ```
 
 ### .unwatch()

--- a/index.js
+++ b/index.js
@@ -76,9 +76,7 @@ function compiler(webpackArg) {
                 !state.isCompiling && handler(state.error, state.compilation);
             }
 
-            webpackCompiler.watch(options, baseHandler);
-
-            return compiler;
+            return webpackCompiler.watch(options, baseHandler);
         },
 
         unwatch() {

--- a/lib/observeWebpackCompiler.js
+++ b/lib/observeWebpackCompiler.js
@@ -66,6 +66,12 @@ function observeWebpackCompiler(webpackCompiler) {
     // Listen to when watch mode starts
     webpackCompiler.watch = wrap(webpackCompiler.watch, (watch, options, handler) => {
         state.webpackWatcher = watch.call(webpackCompiler, options, handler);
+
+        return wrap(state.webpackWatcher.invalidate, (invalidate) => {
+            invalidate.call(state.webpackWatcher);
+
+            eventEmitter.emit('invalidate');
+        });
     });
 
     // Listen to when watch mode is closed

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -83,6 +83,7 @@ it('should emit the correct events if a compilation was canceled via .unwatch()'
 
         finish();
     })
-    .watch()
-    .unwatch();
+    .watch();
+
+    compiler.unwatch();
 });

--- a/test/unwatch.spec.js
+++ b/test/unwatch.spec.js
@@ -23,9 +23,9 @@ it('should stop watching changes (sync)', async () => {
 
     let callsCount = 0;
 
-    const unwatchPromise = compiler
-    .watch(() => { callsCount += 1; })
-    .unwatch();
+    compiler.watch(() => { callsCount += 1; });
+
+    const unwatchPromise = compiler.unwatch();
 
     await Promise.all([unwatchPromise, delay(2000)]);
 

--- a/test/watch.spec.js
+++ b/test/watch.spec.js
@@ -61,6 +61,24 @@ it('should output assets', (done) => {
     });
 });
 
+it('should return a function that can be used to invalidate and retrigger a compilation', (done) => {
+    const compiler = createCompiler(configBasic);
+    const logEvent = jest.fn();
+
+    compiler.once('begin', () => setImmediate(() => invalidate()));
+    compiler.on('begin', () => logEvent('begin'));
+    compiler.on('invalidate', () => logEvent('invalidate'));
+    compiler.on('end', () => logEvent('end'));
+
+    const invalidate = compiler.watch(() => {
+        const loggedEvents = logEvent.mock.calls.reduce((results, [event]) => [...results, event], []);
+
+        expect(loggedEvents).toEqual(['begin', 'invalidate', 'begin', 'end']);
+
+        done();
+    });
+});
+
 describe('args', () => {
     it('should work with .watch()', (done) => {
         const compiler = createCompiler(configBasic);


### PR DESCRIPTION
BREAKING CHANGE: `.watch` no longer returns the compiler and now returns a function that, when called, will stop an ongoing compilation and start a new one. It also emits the `invalidate` event.