### PR TITLE
chore: make tests faster in webpack v4

### DIFF
--- a/test/assertIdle.spec.js
+++ b/test/assertIdle.spec.js
@@ -3,8 +3,6 @@
 const createCompiler = require('./util/createCompiler');
 const configBasic = require('./configs/basic');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should not throw if iddling', () => {

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -16,8 +16,6 @@ function createCompilerWithEvents(...args) {
     return { compiler, events };
 }
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should emit correct events on a successful .run()', async () => {

--- a/test/misc.spec.js
+++ b/test/misc.spec.js
@@ -7,8 +7,6 @@ const saneCompiler = require('../');
 const createCompiler = require('./util/createCompiler');
 const configBasic = require('./configs/basic');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should give access to webpack compiler & config', () => {
@@ -34,7 +32,7 @@ it('should override the webpack compiler\'s outputFileSystem to a fully featured
 });
 
 it('should allow passing a compiler instead of a webpack config', async () => {
-    const webpackCompiler = webpack(createCompiler.uniquifyConfig(configBasic));
+    const webpackCompiler = webpack(createCompiler.prepareConfig(configBasic));
     const compiler = saneCompiler(webpackCompiler);
 
     const { stats } = await compiler.run();

--- a/test/resolve.spec.js
+++ b/test/resolve.spec.js
@@ -5,8 +5,6 @@ const createCompiler = require('./util/createCompiler');
 const configBasic = require('./configs/basic');
 const configSyntaxError = require('./configs/syntax-error');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should fulfill immediately if the compiler has a compilation result', async () => {

--- a/test/run.spec.js
+++ b/test/run.spec.js
@@ -5,8 +5,6 @@ const createCompiler = require('./util/createCompiler');
 const configBasic = require('./configs/basic');
 const configSyntaxError = require('./configs/syntax-error');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should fulfill with the compilation result', async () => {

--- a/test/state.spec.js
+++ b/test/state.spec.js
@@ -4,8 +4,6 @@ const createCompiler = require('./util/createCompiler');
 const configBasic = require('./configs/basic');
 const configSyntaxError = require('./configs/syntax-error');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should have correct state before and after a successful run', async () => {

--- a/test/unwatch.spec.js
+++ b/test/unwatch.spec.js
@@ -5,8 +5,6 @@ const createCompiler = require('./util/createCompiler');
 const touchFile = require('./util/touchFile');
 const configBasic = require('./configs/basic');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should return a promise', () => {

--- a/test/watch.spec.js
+++ b/test/watch.spec.js
@@ -6,8 +6,6 @@ const touchFile = require('./util/touchFile');
 const configBasic = require('./configs/basic');
 const configSyntaxError = require('./configs/syntax-error');
 
-jest.setTimeout(20000);
-
 afterEach(() => createCompiler.teardown());
 
 it('should call the handler everytime a file changes', (done) => {


### PR DESCRIPTION
We were missing the `mode` option, which by default is like `production`.
Everything was slow because minification and other stff was active.